### PR TITLE
removed -p for BSD support. Fixed termination problem.

### DIFF
--- a/http.sh
+++ b/http.sh
@@ -8,10 +8,10 @@ doBreak=0
 trap "doBreak=1" SIGINT
 
 while true; do
-	nc -lp 8080 < pipe | ./http-stdin.sh > pipe
+	nc -l 8080 < pipe | ./http-stdin.sh > pipe
 
 	#if SIGINT has been received, break the loop
-	if [ doBreak=1 ]; then
+	if [ "$doBreak" -eq 1 ]; then
 		break
 	fi
 done


### PR DESCRIPTION
I fixed two issues:
- One was the `netcat` error that depends on which version you run. The `netcat-openBSD` is much newer than `netcat-traditional`. In the newer version of netcat, `-lp` or `-l -p` is considered an error.  I removed the `-p` and it works on all versions (versions listed below). The following is from the BSD netcat manpage, specifically the `-l` flag section:

```
It is an error to use this option in conjunction with
             the -p, -s, or -z options.  Additionally, any timeouts specified with the -w option
             are ignored.
```
- The second issue was that everytime a packet was recieved, the script would exit. I changed the `break` in the `while` loop slightly. The syntax yields more consistent behavior.

_The versions I tested were my debian-based ubuntu, the schools systems, and a mac._
