### PR TITLE
Fixed pipe name conflict

### DIFF
--- a/http.sh
+++ b/http.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 
-# FIXME: what if the file named "pipe" already exists and is being used by something else?
-mkfifo pipe
+#Create a temp folder locally, If it exists, do nothing. 
+([ ! -d tmp_pipes ] && mkdir tmp_pipes) || [ -d tmp_pipes ]
+
+#TMPFILE is a unique filename created in the temp folder.
+TMPFILE=$(mktemp -u tmp_pipes/XXXXXXX) || exit 1
+
+#make a pipe with this unique name
+mkfifo "$TMPFILE"
+
 doBreak=0
 
 #trap SIGINT and cause it to set doBreak to 1
 trap "doBreak=1" SIGINT
 
 while true; do
-	nc -l 8080 < pipe | ./http-stdin.sh > pipe
+	nc -l 8080 < $TMPFILE | ./http-stdin.sh > $TMPFILE
 
 	#if SIGINT has been received, break the loop
 	if [ "$doBreak" -eq 1 ]; then
+		#delete the temp folder
+		rm -r tmp_pipes
 		break
 	fi
 done
 
-
 # FIXME: every other web request has a broken connection;
 # to get the points, you'll have to make every web request succeed
-
-
-


### PR DESCRIPTION
I fixed the "existing pipe" issue. I use `mktemp` to generate a unique file name, then I use `mkfifo` to make a pipe with this name. I opted to store the temp pipes in a local directory. The function`mktemp`, by default, saves its files to the `/tmp/` folder. Someone can modify the `/tmp/` folder and its contents while rapache is running, so I figured this was unsafe. The temp folder I made is created only when the script is running, and deleted when it ends.
