### PR TITLE
Added support for running any executable entered as request in website; querystrings get passed as params to executable

### DIFF
--- a/http-stdin.sh
+++ b/http-stdin.sh
@@ -60,21 +60,29 @@ if [ "$cmd" = "GET" ]; then
         else
             info=$(cat "$file")
     
-            # the file exists, print it to stdout
+            # if the file exists:
             if [ $? = 0 ]; then
 
-                #check content-type via mime-type
-                CONTENT_TYPE=$(file --mime-type "$file")
-                
-                echo "HTTP/1.1 200 OK"
-                echo -ne "Content-type: $CONTENT_TYPE"
-                echo "Content-length: ${#info}"
-                echo ""
-                
-                #Its important that you 'cat' the file, because if it is echo'd, the
-                #binary data can get mangled.
+                # if the file is an executable, we run it
+                if [ -x "$file" ]; then
+                    $file $(tr '&' ' ' <<< "$args")
 
-                cat $file
+                # otherwise, print it to stdout
+                else
+                    #check content-type via mime-type
+                    CONTENT_TYPE=$(file --mime-type "$file")
+                
+                    echo "HTTP/1.1 200 OK"
+                    echo -ne "Content-type: $CONTENT_TYPE"
+                    echo "Content-length: ${#info}"
+                    echo ""
+                
+                    #Its important that you 'cat' the file, because if it is echo'd, the
+                    #binary data can get mangled.
+
+                    cat $file
+
+                fi
 
             # the file could not be accessed
             else


### PR DESCRIPTION
To do: 

1. Add way to `echo` Content-type and Content-length for executable;
2. Create `bash` script called `grades` that will run `calcgrade.sh` and format output correctly for html. For example, you would type in the address `http://<website-name>/grades?user=jduga002` and it would output the grades for `jduga002`.